### PR TITLE
create the hdfs datatype folders dynamcially

### DIFF
--- a/ingest/templates/init-container-start-cmds_secret.yaml
+++ b/ingest/templates/init-container-start-cmds_secret.yaml
@@ -14,8 +14,18 @@ echo "Creating temp dir in hdfs"
 hdfs dfs -mkdir -p hdfs://hdfs-nn:9000/tmp/hadoop-yarn
 hdfs dfs -chmod -R -777 hdfs://hdfs-nn:9000/tmp/
 
-echo "Creating myjson dir"
-hdfs dfs -mkdir -p hdfs://hdfs-nn:9000/data/myjson
+# Create the data ingest folder for the datatypes
+{{- range $key := .Values.ingest.config.types }}
+datatypes="$datatypes {{ $key.flagMakerConfig.liveFolder }}"
+{{- end }}
+echo $datatypes
+for data_type in $datatypes;
+do
+  echo "Creating $data_type dir"
+  hdfs dfs -mkdir -p hdfs://hdfs-nn:9000/data/$data_type
+  hdfs dfs -chmod -R 777 hdfs://hdfs-nn:9000/data/$data_type
+done
+
 echo "Creating classpath dir"
 hdfs dfs -mkdir -p "${DW_ACCUMULO_VFS_DATAWAVE_DIR}"
 

--- a/startLocalTest.ps1
+++ b/startLocalTest.ps1
@@ -1,0 +1,48 @@
+﻿Write-Output "Pulling images down..."
+docker pull rabbitmq:3.11.4-alpine
+docker pull busybox:1.28
+docker pull ghcr.io/nationalsecurityagency/datawave/ingest-kubernetes:6.9.0-SNAPSHOT
+Write-Output "Setting up minikube..."
+minikube delete --all --purge
+minikube start --cpus 8 --memory 12000 --disk-size 20480
+Write-Output "Loading rabbitmq into minikube..."
+minikube image load rabbitmq:3.11.4-alpine
+Write-Output "Loading busybox into minikube..."
+minikube image load busybox:1.28
+Write-Output "Loading ingest-kubernetes into minikube..."
+minikube image load ghcr.io/nationalsecurityagency/datawave/ingest-kubernetes:6.9.0-SNAPSHOT
+Write-Output "Enabling ingress in minikube..."
+minikube addons enable ingress
+minikube kubectl -- delete -A ValidatingWebhookConfiguration ingress-nginx-admission
+minikube kubectl -- patch deployment -n ingress-nginx ingress-nginx-controller --type='json' -p="[{'op': 'add', 'path': '/spec/template/spec/containers/0/args/-', 'value':'--enable-ssl-passthrough'}]"
+
+Write-Output "Setting up GHCR secret..."
+if (Test-Path .\ghcr-image-pull-secret.yaml) {
+    Write-Output "apply secret!!"
+    minikube kubectl -- apply -f ./ghcr-image-pull-secret.yaml
+}
+
+Write-Output "Clearing out old tgz files..."
+mkdir .\umbrella\charts -Force
+foreach($zip_item in (Get-ChildItem -Recurse -Include *.tgz)) {
+    Remove-Item $zip_item.FullName
+}
+
+Write-Output "Packaging helm charts..."
+# Create the individual tar balls and copy them to umbrella
+foreach($folder in ("hadoop", "accumulo", "zookeeper", "ingest", "web")) {
+    Write-Output $folder
+    Set-Location $folder
+    helm lint .
+    helm package .
+    Copy-Item *.tgz ../umbrella/charts/
+    Set-Location ..
+}
+
+Write-Output "Packaging and deploying Umbrella..."
+# Deploy umbrella
+Set-Location umbrella
+helm lint .
+helm package .
+helm install dwv datawave-system-3.40.0.tgz -f "values-testing.yaml"
+Set-Location ..


### PR DESCRIPTION
Within the ingest initialization, dynamically create the live-ingest folders for each data type found within the values.yaml file under the config.types field.

Also created a startLocalTest version for Windows using powershell. 