### PR TITLE
Correctly apply service name, labels, and selectors

### DIFF
--- a/audit/templates/audit-service.yaml
+++ b/audit/templates/audit-service.yaml
@@ -10,13 +10,9 @@ kind: Service
 ######################################
 
 metadata:
-  name: {{ if and (hasKey .Values "service") (hasKey .Values.service "name") }}
-            {{ .Values.service.name }}
-         {{ else }}
-            {{ .Values.meta.name }}
-         {{ end }}
+  name: {{ default .Values.meta.name (.Values.service).name }}
   labels:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name | quote }}
 
 ##################################
 # Complete Service Specification #
@@ -29,7 +25,7 @@ spec:
   ###############################
 
   selector:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name }}
 
   ##############################
   # Service Port Configuration #

--- a/audit/values.schema.json
+++ b/audit/values.schema.json
@@ -130,6 +130,14 @@
             },
             "type": "object"
         },
+        "service": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ports": {
             "properties": {
                 "http": {

--- a/audit/values.yaml
+++ b/audit/values.yaml
@@ -38,6 +38,8 @@ livenessProbe:
   uri: audit/mgmt/health
 meta:
   name: audit
+service:
+  name: audit-service
 readinessProbe:
   delaySeconds: 60
   periodSeconds: 5

--- a/authorization/templates/authorization-service.yaml
+++ b/authorization/templates/authorization-service.yaml
@@ -13,13 +13,9 @@ metadata:
   annotations:
     kompose.cmd: kompose convert
     kompose.version: 1.19.0 (f63a961c)
-  name: {{ if and (hasKey .Values "service") (hasKey .Values.service "name") }}
-            {{ .Values.service.name }}
-         {{ else }}
-            {{ .Values.meta.name }}
-         {{ end }}
+  name: {{ default .Values.meta.name (.Values.service).name }}
   labels:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name | quote }}
 
 ##################################
 # Complete Service Specification #
@@ -32,7 +28,7 @@ spec:
   ###############################
 
   selector:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name }}
 
   ##############################
   # Service Port Configuration #

--- a/authorization/values.schema.json
+++ b/authorization/values.schema.json
@@ -120,6 +120,14 @@
             },
             "type": "object"
         },
+        "service": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ports": {
             "properties": {
                 "http": {

--- a/cache/templates/cache-service.yaml
+++ b/cache/templates/cache-service.yaml
@@ -13,13 +13,9 @@ metadata:
   annotations:
     kompose.cmd: kompose convert
     kompose.version: 1.19.0 (f63a961c)
-  name: {{ if and (hasKey .Values "service") (hasKey .Values.service "name") }}
-            {{ .Values.service.name }}
-         {{ else }}
-            {{ .Values.meta.name }}
-         {{ end }}
+  name: {{ default .Values.meta.name (.Values.service).name }}
   labels:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name | quote }}
 
 ##################################
 # Complete Service Specification #
@@ -32,7 +28,7 @@ spec:
   ###############################
 
   selector:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name }}
 
   ##############################
   # Service Port Configuration #

--- a/cache/values.schema.json
+++ b/cache/values.schema.json
@@ -114,6 +114,14 @@
             },
             "type": "object"
         },
+        "service": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ports": {
             "properties": {
                 "hazelcast1": {

--- a/configuration/templates/configuration-service.yaml
+++ b/configuration/templates/configuration-service.yaml
@@ -10,13 +10,9 @@ kind: Service
 ######################################
 
 metadata:
-  name: {{ if and (hasKey .Values "service") (hasKey .Values.service "name") }}
-            {{ .Values.service.name }}
-         {{ else }}
-            {{ .Values.meta.name }}
-         {{ end }}
+  name: {{ default .Values.meta.name (.Values.service).name }}
   labels:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name | quote }}
 
 ##################################
 # Complete Service Specification #
@@ -29,7 +25,7 @@ spec:
   ###############################
 
   selector:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name }}
 
   ##############################
   # Service Port Configuration #

--- a/configuration/values.schema.json
+++ b/configuration/values.schema.json
@@ -251,6 +251,14 @@
             },
             "type": "object"
         },
+        "service": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ports": {
             "properties": {
                 "default": {

--- a/dictionary/templates/dictionary-service.yaml
+++ b/dictionary/templates/dictionary-service.yaml
@@ -13,13 +13,9 @@ metadata:
   annotations:
     kompose.cmd: kompose convert
     kompose.version: 1.19.0 (f63a961c)
-  name: {{ if and (hasKey .Values "service") (hasKey .Values.service "name") }}
-            {{ .Values.service.name }}
-         {{ else }}
-            {{ .Values.meta.name }}
-         {{ end }}
+  name: {{ default .Values.meta.name (.Values.service).name }}
   labels:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name | quote }}
 
 ##################################
 # Complete Service Specification #
@@ -32,7 +28,7 @@ spec:
   ###############################
 
   selector:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name }}
 
   ##############################
   # Service Port Configuration #

--- a/dictionary/values.schema.json
+++ b/dictionary/values.schema.json
@@ -147,6 +147,14 @@
             },
             "type": "object"
         },
+        "service": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ports": {
             "properties": {
                 "http": {

--- a/rabbitmq/templates/rabbitmq-service.yaml
+++ b/rabbitmq/templates/rabbitmq-service.yaml
@@ -10,13 +10,9 @@ kind: Service
 ######################################
 
 metadata:
-  name: {{ if and (hasKey .Values "service") (hasKey .Values.service "name") }}
-            {{ .Values.service.name }}
-         {{ else }}
-            {{ .Values.meta.name }}
-         {{ end }}
+  name: {{ default .Values.meta.name (.Values.service).name }}
   labels:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name | quote }}
 
 ##################################
 # Complete Service Specification #
@@ -29,7 +25,7 @@ spec:
   ###############################
 
   selector:
-    application: "{{ .Values.meta.name }}"
+    application: {{ .Values.meta.name | quote }}
 
   ##############################
   # Service Port Configuration #

--- a/rabbitmq/values.schema.json
+++ b/rabbitmq/values.schema.json
@@ -81,6 +81,14 @@
             },
             "type": "object"
         },
+        "service": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ports": {
             "properties": {
                 "amqp": {

--- a/startLocalTest.sh
+++ b/startLocalTest.sh
@@ -5,7 +5,7 @@ VALUES_FILE=${1:-values-testing.yaml}
 docker pull rabbitmq:3.11.4-alpine && \
 docker pull busybox:1.28 && \
 minikube delete --all --purge && \
-minikube start --cpus 8 --memory 30960 --disk-size 20480 --kubernetes-version=1.26.0 && \
+minikube start --cpus 8 --memory 30960 --disk-size 20480 && \
 minikube image load rabbitmq:3.11.4-alpine  && \
 minikube image load busybox:1.28 && \
 minikube image load mysql:8.0.32 && \


### PR DESCRIPTION
addresses some issues post merge of #34 

metadata.name will always apply the service.name if available otherwise fall back to meta.name
labels.application will be properly quoted
selector.application is no longer quoted
removed the minikube bind to kubectl version 1.16.0