### PR TITLE
Fix several typos found across documentation files:

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -25,12 +25,12 @@ When performing an upgrade that contains any datatype changes, you may need to r
 ##### Checking the datatype folders were created
 1) remote into the hadoop-nn pod (any of them if there is more than 1)
 1) run the following cmd: `hdfs dfs -ls hdfs://hdfs-nn:9000/data`
-3) verify all the datatype folders exists
+3) verify all the datatype folders exist
 
 ### New Datatype Configuration Help
 <details>
 <summary>Example of what to add</summary>
-The new sction will need to follow the following format:
+The new section will need to follow the following format:
 
 ```yaml
 - name: <name of the datatype>
@@ -38,7 +38,7 @@ The new sction will need to follow the following format:
           liveFolder: <name of datatype>
           bulkFolder: <name of datatype>-bulk
           config:
-            distrubutionArgs: none
+            distributionArgs: none
             extraIngestArgs: "-data.name.override=<name of datatype>"
             inputFormat: datawave.ingest.json.mr.input.JsonInputFormat
             lifo: false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Running this stack uses images in the ghcr repository which are not public. The 
 Through the GitHub UI, generate a PAT with at least read packages
 
 ```bash
-./create-image-pull-secrets.sh <github username> <gihub PAT>
+./create-image-pull-secrets.sh <github username> <github PAT>
 ```
 
 

--- a/hadoop/README.md
+++ b/hadoop/README.md
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the Hadoop chart and th
 | ------------------------------------------------- | -------------------------------                                                    | ---------------------------------------------------------------- |
 | `image.repository`                                | Hadoop image ([source](https://github.com/Comcast/kube-yarn/tree/master/image))    | `danisla/hadoop`                                                 |
 | `image.tag`                                       | Hadoop image tag                                                                   | `2.9.0`                                                          |
-| `imagee.pullPolicy`                               | Pull policy for the images                                                         | `IfNotPresent`                                                   |
+| `image.pullPolicy`                               | Pull policy for the images                                                         | `IfNotPresent`                                                   |
 | `hadoopVersion`                                   | Version of hadoop libraries being used                                             | `2.9.0`                                                          |
 | `antiAffinity`                                    | Pod antiaffinity, `hard` or `soft`                                                 | `hard`                                                           |
 | `hdfs.nameNode.pdbMinAvailable`                   | PDB for HDFS NameNode                                                              | `1`                                                              |


### PR DESCRIPTION
- `README.md`: `gihub` → `github`
- `CONFIG.md`: `sction` → `section`
- `CONFIG.md`: `distrubutionArgs` → `distributionArgs`
- `CONFIG.md`: `folders exists` → `folders exist` (subject-verb agreement)
- `hadoop/README.md`: `imagee.pullPolicy` → `image.pullPolicy`