### PR TITLE
Enable/Disable Accumulo Services Separately

### DIFF
--- a/accumulo/templates/compaction-coordinator-service.yaml
+++ b/accumulo/templates/compaction-coordinator-service.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.coordinator.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +17,4 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 80
+{{- end }}

--- a/accumulo/templates/compaction_coordinator_deployment.yaml
+++ b/accumulo/templates/compaction_coordinator_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.coordinator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,3 +80,4 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}

--- a/accumulo/templates/compactor_statefulset.yaml
+++ b/accumulo/templates/compactor_statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.compactors.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,4 +102,5 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/accumulo/templates/entrypoint-configmap.yaml
+++ b/accumulo/templates/entrypoint-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.entrypointConfigMap.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -54,4 +55,5 @@ data:
     
     exec /usr/bin/dumb-init -- "$@"
 
+{{- end }}
   

--- a/accumulo/templates/gc-service.yaml
+++ b/accumulo/templates/gc-service.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.gc.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +17,4 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 80
+{{- end }}

--- a/accumulo/templates/gc_deployment.yaml
+++ b/accumulo/templates/gc_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gc.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,3 +80,4 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}

--- a/accumulo/templates/manager_deployment.yaml
+++ b/accumulo/templates/manager_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.manager.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +21,7 @@ metadata:
     {{- include "accumulo.labels" . | nindent 4 }}
     app.kubernetes.io/component: manager
 spec:
-  replicas: 1
+  replicas: {{ .Values.manager.replicaCount }}
   selector:
     matchLabels:
       {{- include "accumulo.selectorLabels" . | nindent 6 }}
@@ -107,3 +108,4 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}

--- a/accumulo/templates/manager_service.yaml
+++ b/accumulo/templates/manager_service.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.manager.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +17,4 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 80
+{{- end }}

--- a/accumulo/templates/monitor_deployment.yaml
+++ b/accumulo/templates/monitor_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitor.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,3 +106,4 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}

--- a/accumulo/templates/monitor_ingress.yaml
+++ b/accumulo/templates/monitor_ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitor.enabled }}
 {{- /*
 
 Copyright 2020 Crown Copyright
@@ -47,4 +48,5 @@ spec:
     {{- if ne .Values.monitor.ingress.host "" }}
     host: {{ .Values.monitor.ingress.host }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/accumulo/templates/monitor_service.yaml
+++ b/accumulo/templates/monitor_service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitor.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,3 +30,4 @@ spec:
     protocol: TCP
     port: 80
     targetPort: http
+{{- end }}

--- a/accumulo/templates/post-install-cmds_hook.yaml
+++ b/accumulo/templates/post-install-cmds_hook.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.config.chartProvides }}
 {{- if or .Values.config.userManagement.users .Values.config.postInstallCommands }}
 apiVersion: v1
 kind: Pod
@@ -66,4 +66,5 @@ spec:
   - name: {{ . }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/accumulo/templates/post-install-cmds_secret.yaml
+++ b/accumulo/templates/post-install-cmds_secret.yaml
@@ -133,6 +133,7 @@ if (revokeEnabled == 'true') {
 
 {{- end -}}
 
+{{- if .Values.config.chartProvides }}
 {{- if or .Values.config.userManagement.users .Values.config.postInstallCommands }}
 apiVersion: v1
 kind: Secret
@@ -145,4 +146,5 @@ data:
   run.sh: {{ include "accumulo.accumuloCommandsScript" . | b64enc }}
   accumulo-user-management.js: {{ include "accumulo.accumuloUserManagementScript" . | b64enc }}
   commands.txt: {{ include "accumulo.accumuloCommandsFile" . | b64enc }}
+{{- end }}
 {{- end }}

--- a/accumulo/templates/scanserver_statefulset.yaml
+++ b/accumulo/templates/scanserver_statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scanServers.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,4 +106,5 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/accumulo/templates/sserver_service.yaml
+++ b/accumulo/templates/sserver_service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scanServers.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,20 +34,4 @@ spec:
     port: 80
     targetPort: 80
 {{ end }}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+{{- end }}

--- a/accumulo/templates/tserver_service.yaml
+++ b/accumulo/templates/tserver_service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tabletServers.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,20 +31,4 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 80
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+{{- end }}

--- a/accumulo/templates/tserver_statefulset.yaml
+++ b/accumulo/templates/tserver_statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tabletServers.enabled }}
 # Copyright 2020 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,3 +98,4 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}

--- a/accumulo/values.schema.json
+++ b/accumulo/values.schema.json
@@ -24,6 +24,60 @@
             },
             "type": "object"
         },
+        "compactors": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "queues": {
+                    "items": {
+                        "properties": {
+                            "compactorQueueName": {
+                                "type": "string"
+                            },
+                            "jsonConfig": {
+                                "type": "string"
+                            },
+                            "plannerClass": {
+                                "type": "string"
+                            },
+                            "serviceName": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "coordinator": {
+            "properties": {
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "config": {
             "properties": {
                 "accumuloSite": {

--- a/accumulo/values.schema.json
+++ b/accumulo/values.schema.json
@@ -58,6 +58,9 @@
                 "auths": {
                     "type": "string"
                 },
+                "chartProvides": {
+                    "type": "boolean"
+                },
                 "files": {
                     "properties": {},
                     "type": "object"
@@ -124,6 +127,9 @@
         },
         "entrypointConfigMap": {
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 }
@@ -138,6 +144,9 @@
                 "affinity": {
                     "properties": {},
                     "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "nodeSelector": {
                     "properties": {},
@@ -274,9 +283,15 @@
                     "properties": {},
                     "type": "object"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "nodeSelector": {
                     "properties": {},
                     "type": "object"
+                },
+                "replicaCount": {
+                    "type": "integer"
                 },
                 "resources": {
                     "properties": {},
@@ -293,6 +308,9 @@
                 "affinity": {
                     "properties": {},
                     "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "ingress": {
                     "properties": {
@@ -330,6 +348,9 @@
         },
         "scanServers": {
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "resourceGroups": {
                     "items": {
                         "properties": {
@@ -409,6 +430,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "nodeSelector": {
                     "properties": {},

--- a/accumulo/values.yaml
+++ b/accumulo/values.yaml
@@ -33,7 +33,8 @@ labels: {}
 hadoop:
   classpath:
     "/usr/local/hadoop/etc/hadoop:/usr/local/hadoop/lib/*:/usr/local/hadoop/.//*:/usr/local/hadoop-hdfs/./:/usr/local/hadoop-hdfs/lib/*:/usr/local/hadoop-hdfs/.//*:/usr/local/hadoop-mapreduce/.//*:/usr/local/hadoop-yarn/./:/usr/local/hadoop-yarn/lib/*:/usr/local/hadoop-yarn/.//*"
-entrypointConfigMap: 
+entrypointConfigMap:
+  enabled: true
   name: accumulo-entrypoint
 hostNetwork: {}
 hdfs:
@@ -51,6 +52,7 @@ hdfs:
 zookeeper:
   externalHosts: "zookeeper"
 config:
+  chartProvides: true
   auths: "JBOSS_ADMIN,DW_ADMIN,AUTH_USER,BAR,FOO,PRIVATE,PUBLIC"
   path: /opt/accumulo/conf
   files: {}
@@ -90,11 +92,14 @@ image:
   
   pullPolicy: IfNotPresent
 manager:
+  enabled: true
+  replicaCount: 1
   resources: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
 tabletServers:
+  enabled: true
   replicaCount: 3
   resources: {}
   nodeSelector: {}
@@ -110,12 +115,14 @@ tabletServers:
             - tserver
         topologyKey: "kubernetes.io/hostname"
 compactors:
+  enabled: true
   queues:
     - compactorQueueName: test
       serviceName: testCompactionService
       jsonConfig: "[{\"name\":\"queue1\", \"type\": \"external\", \"queue\":\"test\"}]"
       plannerClass: org.apache.accumulo.core.spi.compaction.DefaultCompactionPlanner
 scanServers:
+  enabled: true
   resourceGroups:
   - resourceGroupName: group1
     replicaCount: 1
@@ -130,12 +137,14 @@ scanServers:
     tolerations: []
     affinity: {}
 gc:
+  enabled: true
   replicaCount: 1
   resources: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
 coordinator:
+  enabled: true
   replicaCount: 1
   resources: {}
   nodeSelector: {}
@@ -147,6 +156,7 @@ cmds:
   tolerations: []
   affinity: {}
 monitor:
+  enabled: true
   replicaCount: 1
   resources: {}
   nodeSelector: {}


### PR DESCRIPTION
This allows for each accumulo service to be enabled/disabled, allowing you to pick and choose what you want to render into the final chart. This allows you to control what you run in different environments by just overriding values in values.yaml. It also avoids rendering charts that are disabled, making chart review easier during troubleshooting.